### PR TITLE
Editing the ENLSP proceeding v262

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,10 +11,10 @@ sections:
   title: Model Efficiency \& Compression
 - name: Inference
   title: Inference
-- name: " Benchmark \\& Evaluation"
-  title: " Benchmark \\& Evaluation"
-- name: 'Applications '
-  title: 'Applications '
+- name: Benchmark \& Evaluation
+  title:  Benchmark \& Evaluation
+- name: Applications
+  title: Applications
 volume: '262'
 year: '2024'
 start: &1 2024-12-14

--- a/enlsp24.bib
+++ b/enlsp24.bib
@@ -177,7 +177,7 @@ However, it is not a popular technique for compressing the AI models duo to the 
     pages = {232-240},
     abstract = {The Lottery Ticket hypothesis proposes that ideal, sparse subnetworks, called lottery tickets, exist in untrained dense neural networks. The Early Bird hypothesis proposes an efficient algorithm to find these winning lottery tickets in convolutional neural networks, using the novel concept of distance between subnetworks to detect convergence in the subnetworks of a model. However, this approach overlooks unchanging groups of unimportant neurons near the search's end. We propose WORM, a method that exploits these static groups by truncating their gradients, forcing the model to rely on other neurons. Experiments show WORM achieves faster ticket identification during training on convolutional neural networks, despite the additional computational overhead, when compared to EarlyBird Search. Additionally, WORM-pruned models lose less accuracy during pruning and recover accuracy faster, improving the robustness of a given model. Furthermore, WORM is also able to generalize the Early Bird hypothesis reasonably well to larger models, such as transformers, displaying its flexibility to adapt to more complex architectures.}
 }
-%#73 no correction
+
 @InProceedings{sharify2024post,
     title = {Post Training Quantization of Large Language Models with Microscaling Formats},
     section = {Model Efficiency \& Compression},


### PR DESCRIPTION
Hi Neil, 

Happy New Year!
Thanks for your effort on putting our proceeding out before the NeurIPS workshop. We have noticed recently that two sections of our proceedings at the bottom of the page are missing: "Benchmarks \& Evaluations" and "Applications". 
It might be because of mismatch int their names in the _config.yml file. I tried to edit that and create a pull request. I appreciate it if you can take a look. Thanks!