### PR TITLE
Fix author list in 2024-12-10-seng-chua24a.md

### DIFF
--- a/_posts/2024-12-10-seng-chua24a.md
+++ b/_posts/2024-12-10-seng-chua24a.md
@@ -23,16 +23,14 @@ lastpage: 221
 page: 206-221
 order: 206
 cycles: false
-bibtex_author: Seng Chua, Vui and Pan, Yujie and Jain, Nilesh and Seng Chua, Vui
+bibtex_author: Chua, Vui Seng and Pan, Yujie and Jain, Nilesh
 author:
-- given: Vui
-  family: Seng Chua
+- given: Vui Seng
+  family: Chua
 - given: Yujie
   family: Pan
 - given: Nilesh
   family: Jain
-- given: Vui
-  family: Seng Chua
 date: 2024-12-10
 address:
 container-title: Proceedings of The 4th NeurIPS Efficient Natural Language and Speech


### PR DESCRIPTION
Dear editors,

We are authors of "Post-Training Statistical Calibration for Higher Activation Sparsity" and would like to fix the author list:

- Somehow there is a duplicate name in the author list. Removed that.
- Updated the family/given name for Chua, Vui Seng.

These changes are aligned with https://raw.githubusercontent.com/mlresearch/v262/main/assets/seng-chua24a/seng-chua24a.pdf

Thanks!

cc @vuiseng9 @nkjain @gopikrishnajha